### PR TITLE
Fixed bug where follow count is always displayed as 0 when not logged in

### DIFF
--- a/src/components/follow.tsx
+++ b/src/components/follow.tsx
@@ -30,20 +30,11 @@ const Follow: React.FC<FollowProps> = ({ fileName, loggedIn }) => {
 
     // Fetch follow count
     const fetchFollowCount = async () => {
-      
-      const token = localStorage.getItem("authToken");
-      if (!token) {
-        console.error("No token found for fetching follow count.");
-        return;
-      }
       try {
-        
         const response = await axios.get(`${uploadServer}/get-follow-count`, {
-          params: { fileName },
-          headers: { Authorization: token },
+          params: { fileName },   
         });
         // console.log("Follow count response:", response.data); // Debugging log
-
         setFollowCount(response.data.follow_count || 0); 
         // alert(followCount); // Display the follow count in an alert
       } catch (error) {


### PR DESCRIPTION
Bug fix for getting the follow count correctly when not logged in. Removed auth token from fetchFollowCount so follow count can be correctly retrieved without it.